### PR TITLE
update to SignalR 1.0.1

### DIFF
--- a/Xamarin/FormsClient/FormsClient.UWP/FormsClient.UWP.csproj
+++ b/Xamarin/FormsClient/FormsClient.UWP/FormsClient.UWP.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>FormsClient.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
@@ -144,7 +144,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.4"/>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FormsClient\FormsClient.csproj">

--- a/Xamarin/FormsClient/FormsClient/FormsClient.csproj
+++ b/Xamarin/FormsClient/FormsClient/FormsClient.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.469394-pre1" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update to SignalR 1.0.1 and set the min version of the FormsClient.UWP project to Windows 10, version 1803 to exhibit the System.Threading.Tasks.Extensions issue.

With this change, Android/iOS is broken again as the System.Threading.Tasks.Extensions package was marked in-box but is not yet in the box.